### PR TITLE
Add note for OAuth refresh

### DIFF
--- a/source/includes/_oauth.md
+++ b/source/includes/_oauth.md
@@ -247,6 +247,8 @@ $result = $OAuth->refresh($refreshToken);
 
 Use a valid `refresh_token` to generate a new `access_token` and `refresh_token` pair.
 
+**NOTE:** The `refresh_token` you receive will *change* every time you exchange either an `authorization_code` or `refresh_token` for a new token pair. Only the most recently issued `refresh_token` will allow you to receive a new pair.
+
 ### HTTP Request
 `POST https://www.dwolla.com/oauth/v2/token`
 


### PR DESCRIPTION
Some feedback has lead me to believe that the refresh flow is ambiguous to some partners. Most recently, a user messaged us about one of our libraries acting up when they were passing in old `refresh_token`s. It did not occur to them to store the newly issued `refresh_token`. 

This little addendum should hopefully mitigate these kinds of problems. 